### PR TITLE
[Bug] Error packaging without PLUSBUILD_DOWNLOAD_PlusDATA

### DIFF
--- a/InstallFiles.cmake
+++ b/InstallFiles.cmake
@@ -14,32 +14,32 @@ IF(BUILD_DOCUMENTATION)
     )
 ENDIF()
 
-SET(PLUSLIB_CONFIG_FILES
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_PivotCalibration.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_RecordPhantomLandmarks.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_SpatialCalibration_2.0.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_TemporalCalibration.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_VolumeReconstruction.xml
+# SET(PLUSLIB_CONFIG_FILES
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_PivotCalibration.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_RecordPhantomLandmarks.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_SpatialCalibration_2.0.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_TemporalCalibration.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_fCal_Sim_VolumeReconstruction.xml
 
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_ChRobotics.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_Microchip.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_Sim_NwirePhantom.xml  
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_SimulatedUltrasound_3DSlicer.xml
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_GelBlockModel_Reference.stl
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_NeedleModel_NeedleTip.stl
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_VesselModel_Reference.stl
-  ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_Scene.mrb
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_ChRobotics.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_Microchip.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_Sim_NwirePhantom.xml  
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_SimulatedUltrasound_3DSlicer.xml
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_GelBlockModel_Reference.stl
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_NeedleModel_NeedleTip.stl
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_VesselModel_Reference.stl
+#   ${PLUSLIB_DATA_DIR}/ConfigFiles/SimulatedUltrasound_Scene.mrb
 
-  ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_1.0.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_1.2.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_2.0.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_3.1.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_L1.4.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/LinearProbe/Probe_L14-5_38.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/EndocavityProbe/Probe_EC9-5_10.stl
-  ${PLUSLIB_DATA_DIR}/CADModels/CurvilinearProbe/Probe_C5-2_60.stl 
-  ${PLUSLIB_DATA_DIR}/CADModels/Stylus/Stylus_Example.stl
-  )
+#   ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_1.0.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_1.2.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_2.0.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_3.1.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/fCalPhantom/fCal_L1.4.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/LinearProbe/Probe_L14-5_38.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/EndocavityProbe/Probe_EC9-5_10.stl
+#   ${PLUSLIB_DATA_DIR}/CADModels/CurvilinearProbe/Probe_C5-2_60.stl 
+#   ${PLUSLIB_DATA_DIR}/CADModels/Stylus/Stylus_Example.stl
+#   )
 
 IF(PLUS_USE_3dConnexion_TRACKER)
   LIST(APPEND PLUSLIB_CONFIG_FILES ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_3dConnexion.xml)
@@ -158,13 +158,13 @@ IF(PLUS_USE_VFW_VIDEO)
   LIST(APPEND PLUSLIB_CONFIG_FILES ${PLUSLIB_DATA_DIR}/ConfigFiles/PlusDeviceSet_Server_VfwVideoCapture.xml)
 ENDIF()
 
-SET(PLUSLIB_DATA_FILES
-  ${PLUSLIB_DATA_DIR}/TestImages/fCal_Test_Calibration_3NWires.mha
-  ${PLUSLIB_DATA_DIR}/TestImages/fCal_Test_Calibration_3NWires_fCal2.0.mha
-  ${PLUSLIB_DATA_DIR}/TestImages/WaterTankBottomTranslationTrackerBuffer-trimmed.mha
-  ${PLUSLIB_DATA_DIR}/TestImages/WaterTankBottomTranslationVideoBuffer.mha
-  ${PLUSLIB_DATA_DIR}/TestImages/EightLandmarkPointsTrackedForPhantomRegistration.mha
-  )
+# SET(PLUSLIB_DATA_FILES
+#   ${PLUSLIB_DATA_DIR}/TestImages/fCal_Test_Calibration_3NWires.mha
+#   ${PLUSLIB_DATA_DIR}/TestImages/fCal_Test_Calibration_3NWires_fCal2.0.mha
+#   ${PLUSLIB_DATA_DIR}/TestImages/WaterTankBottomTranslationTrackerBuffer-trimmed.mha
+#   ${PLUSLIB_DATA_DIR}/TestImages/WaterTankBottomTranslationVideoBuffer.mha
+#   ${PLUSLIB_DATA_DIR}/TestImages/EightLandmarkPointsTrackedForPhantomRegistration.mha
+#   )
 
 # Install Qt libs
 SET(PlusApp_QT_INSTALL_FILES


### PR DESCRIPTION
I'm unable to successfully package PlusApp if I unchecked "PLUSBBUILD_DOWNLOAD_PlusData" when I originally configured the cmake for PlusBuild.  I was able to successfully package PlusApp when I commented out the following lines in the InstallFiles.cmake file.  I'll let someone else address how they want to handle this bug rather than just commenting out code.

This was the original package error:
[PACKAGE fail.txt](https://github.com/PlusToolkit/PlusApp/files/1002359/PACKAGE.fail.txt)
