### PR TITLE
Making downstream development simpler

### DIFF
--- a/Documentation/ApplicationPlusServer.dox
+++ b/Documentation/ApplicationPlusServer.dox
@@ -80,7 +80,7 @@ Launch the command-line-only version of PlusServer (no graphical user interface)
       - \xmlElem \b Transform
           - \xmlAtt Name
     - \xmlElem \b StringNames
-      - \xmlElem \b String Name of the custom frame string that is sent as a STRING message. Any frame field (Timestamp, any status message, any custom frame fields) can be specified here.
+      - \xmlElem \b String Name of the frame string that is sent as a STRING message. Any frame field (Timestamp, any status message, any frame fields) can be specified here.
     - \xmlElem \b ImageNames
       - \xmlElem \b Image
           - \xmlAtt Name Name of the image stream. It also defines the "From" frame of the transform embedded in the IGTL image message.

--- a/SpatialSensorFusion/SpatialSensorFusion.cxx
+++ b/SpatialSensorFusion/SpatialSensorFusion.cxx
@@ -170,8 +170,8 @@ int main(int argc, char** argv)
   {
     PlusTrackedFrame* frame = frameList->GetTrackedFrame(frameIndex);
     Update(ahrsAlgo, frame, trackerReferenceFrame, westAxisIndex, true, filteredTiltSensorToTrackerTransform);
-    frame->SetCustomFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), filteredTiltSensorToTrackerTransform);
-    frame->SetCustomFrameTransformStatus(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), FIELD_OK);
+    frame->SetFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), filteredTiltSensorToTrackerTransform);
+    frame->SetFrameTransformStatus(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), FIELD_OK);
   }
 
   if (vtkPlusSequenceIO::Write(outputImgFile, frameList, US_IMG_ORIENT_XX) != PLUS_SUCCESS)
@@ -202,10 +202,10 @@ int main(int argc, char** argv)
       PlusTrackedFrame* baselineFrame = baselineFrameList->GetTrackedFrame(frameIndex);
 
       vtkSmartPointer<vtkMatrix4x4> filteredTilt = vtkSmartPointer<vtkMatrix4x4>::New();
-      frame->GetCustomFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), filteredTilt);
+      frame->GetFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), filteredTilt);
 
       vtkSmartPointer<vtkMatrix4x4> baselineFilteredTilt = vtkSmartPointer<vtkMatrix4x4>::New();
-      baselineFrame->GetCustomFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), baselineFilteredTilt);
+      baselineFrame->GetFrameTransform(PlusTransformName("FilteredTiltSensor", trackerReferenceFrame), baselineFilteredTilt);
 
       //check for element by element equality
       bool matricesDifferent = false;
@@ -254,9 +254,9 @@ void Update(AhrsAlgo* ahrsAlgo, PlusTrackedFrame* frame, const std::string& trac
 {
   double timestamp = frame->GetTimestamp();
   vtkSmartPointer<vtkMatrix4x4> gyroscopeMat = vtkSmartPointer<vtkMatrix4x4>::New();
-  frame->GetCustomFrameTransform(PlusTransformName("Gyroscope", trackerReferenceFrame), gyroscopeMat);
+  frame->GetFrameTransform(PlusTransformName("Gyroscope", trackerReferenceFrame), gyroscopeMat);
   vtkSmartPointer<vtkMatrix4x4> accelerometerMat = vtkSmartPointer<vtkMatrix4x4>::New();
-  frame->GetCustomFrameTransform(PlusTransformName("Accelerometer", trackerReferenceFrame), accelerometerMat);
+  frame->GetFrameTransform(PlusTransformName("Accelerometer", trackerReferenceFrame), accelerometerMat);
 
   if (useTimestamps)
   {

--- a/fCal/Toolboxes/QCapturingToolbox.cxx
+++ b/fCal/Toolboxes/QCapturingToolbox.cxx
@@ -335,7 +335,7 @@ void QCapturingToolbox::TakeSnapshot()
 
   // Check if there are any valid transforms
   std::vector<PlusTransformName> transformNames;
-  trackedFrame.GetCustomFrameTransformNameList(transformNames);
+  trackedFrame.GetFrameTransformNameList(transformNames);
   bool validFrame = false;
 
   if (transformNames.size() == 0)
@@ -347,7 +347,7 @@ void QCapturingToolbox::TakeSnapshot()
     for (std::vector<PlusTransformName>::iterator it = transformNames.begin(); it != transformNames.end(); ++it)
     {
       TrackedFrameFieldStatus status = FIELD_INVALID;
-      trackedFrame.GetCustomFrameTransformStatus(*it, status);
+      trackedFrame.GetFrameTransformStatus(*it, status);
 
       if (status == FIELD_OK)
       {

--- a/fCal/Toolboxes/QTemporalCalibrationToolbox.cxx
+++ b/fCal/Toolboxes/QTemporalCalibrationToolbox.cxx
@@ -697,42 +697,42 @@ void QTemporalCalibrationToolbox::ComputeCalibrationResults()
   {
     switch (error)
     {
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_RESULT_ABOVE_THRESHOLD:
-        double correlation;
-        this->TemporalCalibrationAlgo->GetBestCorrelation(correlation);
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_RESULT_ABOVE_THRESHOLD:
+      double correlation;
+      this->TemporalCalibrationAlgo->GetBestCorrelation(correlation);
 
-        strs << "Result above threshold. " << correlation;
-        errorStr = strs.str();
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_INVALID_TRANSFORM_NAME:
-        errorStr = "Invalid transform name.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_TIMESTAMPS:
-        errorStr = "No timestamps on data.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_UNABLE_NORMALIZE_METRIC:
-        errorStr = "Unable to normalize the data.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_CORRELATION_RESULT_EMPTY:
-        errorStr = "Correlation list empty. Unable to perform analysis on data.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_VIDEO_DATA:
-        errorStr = "Missing video data.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NOT_MF_ORIENTATION:
-        errorStr = "Data not in MF orientation.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NOT_ENOUGH_FIXED_FRAMES:
-        errorStr = "Not enough frames in fixed signal.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_FRAMES_IN_ULTRASOUND_DATA:
-        errorStr = "No frames in ultrasound data.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_SAMPLING_RESOLUTION_TOO_SMALL:
-        errorStr = "Sampling resolution too small.";
-        break;
-      case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NONE:
-        break;
+      strs << "Result above threshold. " << correlation;
+      errorStr = strs.str();
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_INVALID_TRANSFORM_NAME:
+      errorStr = "Invalid transform name.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_TIMESTAMPS:
+      errorStr = "No timestamps on data.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_UNABLE_NORMALIZE_METRIC:
+      errorStr = "Unable to normalize the data.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_CORRELATION_RESULT_EMPTY:
+      errorStr = "Correlation list empty. Unable to perform analysis on data.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_VIDEO_DATA:
+      errorStr = "Missing video data.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NOT_MF_ORIENTATION:
+      errorStr = "Data not in MF orientation.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NOT_ENOUGH_FIXED_FRAMES:
+      errorStr = "Not enough frames in fixed signal.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NO_FRAMES_IN_ULTRASOUND_DATA:
+      errorStr = "No frames in ultrasound data.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_SAMPLING_RESOLUTION_TOO_SMALL:
+      errorStr = "Sampling resolution too small.";
+      break;
+    case vtkPlusTemporalCalibrationAlgo::TEMPORAL_CALIBRATION_ERROR_NONE:
+      break;
     }
 
     LOG_ERROR("Cannot determine tracker lag, temporal calibration failed! Error: " << errorStr);
@@ -1081,7 +1081,7 @@ void QTemporalCalibrationToolbox::FixedSignalChanged(int newIndex)
     repo->SetTransforms(frame);
 
     std::vector<PlusTransformName> nameList;
-    frame.GetCustomFrameTransformNameList(nameList);
+    frame.GetFrameTransformNameList(nameList);
     std::vector<std::string> fromList;
     std::vector<std::string> toList;
     for (std::vector<PlusTransformName>::iterator it = nameList.begin(); it != nameList.end(); ++it)
@@ -1158,7 +1158,7 @@ void QTemporalCalibrationToolbox::MovingSignalChanged(int newIndex)
     repo->SetTransforms(frame);
 
     std::vector<PlusTransformName> nameList;
-    frame.GetCustomFrameTransformNameList(nameList);
+    frame.GetFrameTransformNameList(nameList);
     std::vector<std::string> fromList;
     std::vector<std::string> toList;
     for (std::vector<PlusTransformName>::iterator it = nameList.begin(); it != nameList.end(); ++it)


### PR DESCRIPTION
Removing 'Custom' prefix from function names as it does not differentiate between non-Custom frame entries

See PlusToolkit/PlusLib#389