### PR TITLE
Fixed broken build 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,12 +308,6 @@ ENDIF()
 
 ADD_SUBDIRECTORY(Documentation)
 
-#-----------------------------------------------------------------------------
-# Include PlusLib MS projects
-# --------------------------------------------------------------------------
-INCLUDE_PLUSLIB_MS_PROJECTS()
-GROUP_PLUSLIB_MS_PROJECTS("PlusLib")
-
 SET(PLUSAPP_INCLUDE_DIRS
   ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
The INCLUDE_PLUSLIB_MS_PROJECTS and GROUP_PLUSLIB_MS_PROJECTS macros were removed from PlusLib src/UsePlusLib.cmake.in file which prevents PlusApp from configuring correctly. This causes a clean build to fail.